### PR TITLE
Multiple interface and device support

### DIFF
--- a/cmd/nsdp-cli/main.go
+++ b/cmd/nsdp-cli/main.go
@@ -103,6 +103,7 @@ func main() {
 	var (
 		password = flag.String("password", "", "switch password (required when setting values)")
 		netdevice = flag.String("device", "", "network interface to use (default first non loopback)")
+		target = flag.String("target", "00:00:00:00:00:00", "target MAC address of switch")
 	)
 	flag.Usage = usage
 	flag.Parse()
@@ -115,7 +116,7 @@ func main() {
 	action := positionalArgs[0]
 	tlvs := ConvertCmdsToTLVs(positionalArgs[1:])
 
-	c, err := nsdp.NewDefaultClient(*netdevice)
+	c, err := nsdp.NewDefaultClient(*netdevice, *target)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/nsdp-cli/main.go
+++ b/cmd/nsdp-cli/main.go
@@ -102,6 +102,7 @@ func ConvertCmdsToTLVs(cmds []string) []nsdp.TLV {
 func main() {
 	var (
 		password = flag.String("password", "", "switch password (required when setting values)")
+		netdevice = flag.String("device", "", "network interface to use (default first non loopback)")
 	)
 	flag.Usage = usage
 	flag.Parse()
@@ -114,7 +115,7 @@ func main() {
 	action := positionalArgs[0]
 	tlvs := ConvertCmdsToTLVs(positionalArgs[1:])
 
-	c, err := nsdp.NewDefaultClient()
+	c, err := nsdp.NewDefaultClient(*netdevice)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/nsdp/client.go
+++ b/nsdp/client.go
@@ -60,7 +60,7 @@ func NewDefaultClient() (*Client, error) {
 		return nil, err
 	}
 
-	anyAddr, err := net.ResolveUDPAddr("udp", "255.255.255.255:63322")
+	anyAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(DefaultDestAddr, DefaultSendPort))
 	if err != nil {
 		return nil, err
 	}

--- a/nsdp/client.go
+++ b/nsdp/client.go
@@ -17,7 +17,7 @@ const (
 )
 
 // get first non-loopback address, intf-name and mac
-func getSelfIntfAndIp() (string, string, []byte, error) {
+func getSelfIntfAndIp(device string) (string, string, []byte, error) {
 	intfs, err := net.Interfaces()
 	if err != nil {
 		return "", "", nil, err
@@ -26,6 +26,9 @@ func getSelfIntfAndIp() (string, string, []byte, error) {
 	for _, intf := range intfs {
 		addrs, err := intf.Addrs()
 		if err != nil {
+			continue
+		}
+		if device != "" && intf.Name != device {
 			continue
 		}
 
@@ -49,8 +52,8 @@ type Client struct {
 	seq          uint16
 }
 
-func NewDefaultClient() (*Client, error) {
-	selfAddrStr, _, intfHwAddr, err := getSelfIntfAndIp()
+func NewDefaultClient(device string) (*Client, error) {
+	selfAddrStr, _, intfHwAddr, err := getSelfIntfAndIp(device)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Allows to specify which network interface to use instead of just using first one
- Allows to specify target switch when multiple switches are reachable